### PR TITLE
Fix the error

### DIFF
--- a/piu-piu
+++ b/piu-piu
@@ -292,7 +292,6 @@ function mover () { er=${#sprite[@]}
 	[ $OX -lt 1 ] && {
 		remove_obj ${i}
 		case ${type} in "alien") ((enumber--));; esac
-		continue
 	}
 
 	for (( p=0; p<${er}; p++ )); do


### PR DESCRIPTION
Bash says `./piu-piu: line 295: continue: only meaningful in a 'for', 'while', or 'until' loop`
                                                                                     
Removing `continue` actually works. 