### PR TITLE
Better handling user custom bash version

### DIFF
--- a/piu-piu
+++ b/piu-piu
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # check bash version
 case ${BASH_VERSINFO[@]::2} in [1-3]' '[0-9][0-9]|[1-3]' '[0-9]|'4 '[0-1])


### PR DESCRIPTION
This is my proposal for better handling user custom bash. Example: I'm using macOS 10.11.6 where bash in `/bin/bash` is very old. Piu-Piu doesn't work with this. My regular bash is from Homebrew which is for legacy reason installed in `/usr/local/bin/bash`. So best way to give Piu-Piu current user version is just ask `env` which location of bash user using. This should work with Debian-like distros as well as latest Centos, but must be checked for Bash4Windows users (I don't have any) and probably for older Centos.