### PR TITLE
fix: gawk added to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine
 
 COPY piu-piu /usr/games/
 RUN \
-  apk add --no-cache bash ncurses && \
+  apk add --no-cache bash ncurses gawk && \
   chmod +x /usr/games/piu-piu
 
 EXPOSE 54321 54322


### PR DESCRIPTION
To run the game, you need the gawk package.
Otherwise, an error occurs:

```BASH
docker run -it piu-piu:latest /usr/games/piu-piu                                             
/usr/games/piu-piu: line 39: gawk: command not found

Your BASH is too short!) 4.2+ required to run this game, your is - 5.2.26(1)-release
```